### PR TITLE
Bump @material-ui/data-grid from 4.0.0-alpha.29 to 4.0.0-alpha.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,9 +2826,9 @@
       }
     },
     "@material-ui/data-grid": {
-      "version": "4.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.29.tgz",
-      "integrity": "sha512-dGL9nmiytpjvlY9vFJKUCtXf9eGMb0zxt5+M9hXEKYK8BOYTi+Po5y4YZp4kQ2PojFu78CDz2/gP3u51GxaF3A==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-2lf2WjsJNTVgF0DXlekIZAFap0HHNrjhdoF4tCUXNDu6ZP3helenkFY1aedjSwczQT3coLYe5sSPBVQcxJ0olw==",
       "requires": {
         "@material-ui/utils": "^5.0.0-alpha.14",
         "clsx": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@apollo/client": "^3.3.19",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.11.4",
-    "@material-ui/data-grid": "^4.0.0-alpha.29",
+    "@material-ui/data-grid": "^4.0.0-alpha.30",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/pickers": "^3.3.10",


### PR DESCRIPTION
Bumps @material-ui/data-grid from 4.0.0-alpha.29 to 4.0.0-alpha.30.

Signed-off-by: dependabot[bot] <support@github.com>